### PR TITLE
updated regex for @mentions within streams to support email addresses as usernames

### DIFF
--- a/components/com_stream/libraries/message.php
+++ b/components/com_stream/libraries/message.php
@@ -490,7 +490,8 @@ class StreamMessage
 		$str = StreamTemplate::escape($strMessage);
 		
 		// Autolinked the @username 
-		preg_match_all("/@([\w.]+)/", $str, $matches, PREG_SET_ORDER);
+		// Updated Regex to match lowercase email address as username. matches @user or @user@example.com
+		preg_match_all("/@([a-z_0-9.@]+)|@([a-z_0-9.]+)/", $str, $matches, PREG_SET_ORDER);
 		
 		if(!empty( $matches )) 
 		{


### PR DESCRIPTION
We are in the process of migrating from Jive to Offiria at my company. Since our usernames are email addresses, the current reg ex for the @mentions were not taking into account the '@' symbol within the username. I made an adjustment to handle both @user and @user@example.com.
I believe this can be useful in the future for other installations.
