### PR TITLE
Update for management of the max size of uploaded files. 

### DIFF
--- a/components/com_account/controllers/account.php
+++ b/components/com_account/controllers/account.php
@@ -166,6 +166,7 @@ class AccountControllerAccount extends JController
 			$param['smtphost']		= $postdata['smtphost'];
 			$param['smtpsecure']	= $postdata['smtpsecure'];
 			$param['smtpport']		= $postdata['smtpport'];
+			$param['uploadmaxsize']		= $postdata['uploadmaxsize'];
 			
 			$saveAction = $configHelper->saveConfig($param);
 			

--- a/components/com_account/views/advance/tmpl/default.php
+++ b/components/com_account/views/advance/tmpl/default.php
@@ -128,6 +128,17 @@ $jxConfig = new JXConfig();
 				</ul>
 		</fieldset>
 		
+		<!-- UPLOAD SETTINGS -->
+		<h3 class="section-title"><?php echo JText::_('COM_ACCOUNT_LABEL_UPLOAD');?></h3>
+		<fieldset class="adminform">
+			<ul class="adminformlist">
+				<li>
+					<label id="jform_uploadmaxsize" for="jform_uploadmaxsize" class="hasTip" title=""><?php echo JText::_('COM_ACCOUNT_LABEL_UPLOAD_MAXSIZE');?></label>					
+					<input type="text" name="jform[uploadmaxsize]" id="jform_diffbot" value="<?php echo $this->uploadmaxsize;?>" size="30">
+				</li>
+			</ul>
+		</fieldset>
+		
 		<div class="submit">
 			<input type="hidden" value="advance" name="task">
 			<input class="btn btn-info" type="submit" value="<?php echo JText::_('COM_STREAM_LABEL_SAVE');?>" name="submit">

--- a/components/com_account/views/advance/view.html.php
+++ b/components/com_account/views/advance/view.html.php
@@ -43,6 +43,7 @@ class AccountViewAdvance extends AccountView
 		$smtphost		= $configHelper->get('smtphost');
 		$smtpsecure		= $configHelper->get('smtpsecure');
 		$smtpport		= $configHelper->get('smtpport'); // 25
+		$uploadmaxsize	= $configHelper->get('uploadmaxsize');
 		//overwrite value with postParam when save error
 		$error = array();
 		if ($_POST)
@@ -65,6 +66,7 @@ class AccountViewAdvance extends AccountView
 			$smtphost		= $postParam['smtphost'];
 			$smtpsecure		= $postParam['smtpsecure'];
 			$smtpport		= $postParam['smtpport'];
+			$uploadmaxsize	= $postParam['uploadmaxsize'];
 		}
 		
 
@@ -85,6 +87,7 @@ class AccountViewAdvance extends AccountView
 		$this->assignRef('smtphost', $smtphost);
 		$this->assignRef('smtpsecure', $smtpsecure);
 		$this->assignRef('smtpport', $smtpport);
+		$this->assignRef('uploadmaxsize', $uploadmaxsize);
 		
 		$doc = JFactory::getDocument();
 		$doc->setTitle(JText::_("COM_ACCOUNT_LABEL_ACCOUNT_ADVANCE_SETTING"));

--- a/components/com_stream/controllers/system.php
+++ b/components/com_stream/controllers/system.php
@@ -412,7 +412,12 @@ class StreamControllerSystem extends JController
 		$allowedExtensions = explode(',', $mediaparams->get('upload_extensions'));
 		
 		// max file size in bytes
-		$sizeLimit = 5 * 1024 * 1024;
+		$config = new JConfig();
+		if (isset($config->uploadmaxsize) && ctype_digit(strval($config->uploadmaxsize)) && strval($config->uploadmaxsize) > 0) {
+			$sizeLimit = strval($config->uploadmaxsize) * 1024 * 1024;
+		} else {
+			$sizeLimit = 5 * 1024 * 1024;
+		}
 		
 		$uploader = new qqFileUploader($allowedExtensions, $sizeLimit);
 		

--- a/installer/default/configuration.php
+++ b/installer/default/configuration.php
@@ -71,4 +71,5 @@ class JConfig {
 	public $captcha = '0';
 	public $style = 'blue';
 	public $postfix_domain = '.offiria.com';
+	//___JConfig_END___ Do not delete or modify this line which is used to to add new parameter
 }

--- a/installer/index.php
+++ b/installer/index.php
@@ -53,6 +53,7 @@ if ($_GET) {
 	$admin_email 	  = $_GET['admin_email'];
 	$sitename		  = $_GET['sitename'];
 	$default_timezone = $_GET['default_timezone'];
+	$uploadmaxsize	  = $_GET['uploadmaxsize'];
 
 	// to passed variables
 	$variables = $_SERVER['QUERY_STRING'];
@@ -143,6 +144,9 @@ if ($_GET) {
 	$config->modify('default_timezone', $default_timezone);
 	$config->modify('log_path', INSTALLATION_DIR.DS.'log');
 	$config->modify('tmp_path', INSTALLATION_DIR.DS.'tmp');
+	if (!$config->modify('uploadmaxsize', $uploadmaxsize)) {
+		$config->add('uploadmaxsize', $uploadmaxsize);
+	}
 	if ($canProceed && !$config->save()) {
 		$canProceed = false;
 		$errorMessage = 'Failed to save configuration files';
@@ -389,6 +393,12 @@ if ($_GET) {
 													<option <?php echo $selected; ?> value="<?php echo $key; ?>"><?php echo $value; ?></option>
 													<?php endforeach; ?>
 												</select>
+											</div>
+										</div>
+										<div class="control-group">
+											<label class="control-label" for="domain">Max size for file upload (in MB)</label>
+											<div class="controls">
+												<input class="span3 validate[required,custom[integer],min[1]]" type="text" name="uploadmaxsize" value="<?php echo @$_GET['uploadmaxsize']; ?>" />
 											</div>
 										</div>
 									</div>

--- a/installer/models/config.php
+++ b/installer/models/config.php
@@ -22,7 +22,16 @@ class ConfigManager
 		return $matches;
 	}
 
-	public function add($key, $value) {}
+	public function add($key, $value) {
+		$buffer = $this->buffer;
+		$pattern = "~\t\/\/*.*___JConfig_END___.*~";
+		if (!preg_match($pattern, $buffer, $matches)) return false;
+		
+		$originalLine = $matches[0];
+		$newLine = "\tpublic $".$key." = '".$value."';\n".$originalLine;
+		$this->buffer = str_replace($originalLine, $newLine, $this->buffer);
+		return $this;
+	}
 
 	public function modify($key, $new) {
 		$finder = $this->find($key);

--- a/language/en-GB/en-GB.lib_xjoomla.ini
+++ b/language/en-GB/en-GB.lib_xjoomla.ini
@@ -640,6 +640,9 @@ COM_ACCOUNT_LABEL_SMTP_PORT="SMTP Port"
 COM_ACCOUNT_LABEL_SMTP_USERNAME="SMTP Username"
 COM_ACCOUNT_LABEL_SMTP_PASSWORD="SMTP Password"
 COM_ACCOUNT_LABEL_SMTP_HOST="SMTP Host"
+COM_ACCOUNT_LABEL_UPLOAD="Upload Settings"
+COM_ACCOUNT_LABEL_UPLOAD_MAXSIZE="Max size for file upload (in megabytes)"
+
 
 COM_ACCOUNT_LABEL_HELPER_CROCODOCS = 'Crocodocs accounts are available at <a href="https://crocodoc.com/get-started/" target="_blank">https://crocodoc.com/get-started/</a>. (Free evaluation account is available for trial.)'
 COM_ACCOUNT_LABEL_HELPER_SCRIBD = "Scribd accounts are available at <a href="http://www.scribd.com/developers/signup_api" target="_blank">http://www.scribd.com/developers/signup_api</a>. (Free evaluation account is available for trial.)"

--- a/language/en-GB/en-GB.lib_xjoomla.ini
+++ b/language/en-GB/en-GB.lib_xjoomla.ini
@@ -643,7 +643,6 @@ COM_ACCOUNT_LABEL_SMTP_HOST="SMTP Host"
 COM_ACCOUNT_LABEL_UPLOAD="Upload Settings"
 COM_ACCOUNT_LABEL_UPLOAD_MAXSIZE="Max size for file upload (in megabytes)"
 
-
 COM_ACCOUNT_LABEL_HELPER_CROCODOCS = 'Crocodocs accounts are available at <a href="https://crocodoc.com/get-started/" target="_blank">https://crocodoc.com/get-started/</a>. (Free evaluation account is available for trial.)'
 COM_ACCOUNT_LABEL_HELPER_SCRIBD = "Scribd accounts are available at <a href="http://www.scribd.com/developers/signup_api" target="_blank">http://www.scribd.com/developers/signup_api</a>. (Free evaluation account is available for trial.)"
 COM_ACCOUNT_LABEL_HELPER_DIFFBOT = "Diffbot accounts are available at <a href="https://www.diffbot.com/pricing/" target="_blank">https://www.diffbot.com/pricing/</a>. (Free account for small traffic user is available.) Note: diffbot can sometimes experience delay. Rest assure as long as correct token from Diffbot is provided."


### PR DESCRIPTION
- Added : marker of end of conf as a comment in installer/default/configuration.php in order to permit addition of new parameters,
- Updated : the add method in the Config class in installer/models/config.php in order to permit addition of new parameters,
- Added : setup of the max size for file upload in the installation process in installer/index.php,
- Added : support of the uploadmaxsize parameter in component/com_stream/controllers/system.php,
- Updated : controller, view, template of the advanced settings configuration page with support of modification of the uploadmaxsize parameter.
